### PR TITLE
Added Makefile for building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+CXXFLAGS=--std=c++1y -I`$(LLVMCONFIG) --includedir`
+LLVMCONFIG=llvm-config
+LDLIBS=-lpthread -ldl -lcurses
+
+basiccompiler: basiccompiler.o parser.o lexer.o
+	$(CXX) $(LDFLAGS) -o $@ $^ `$(LLVMCONFIG) --ldflags` `$(LLVMCONFIG) --libs engine bitwriter` $(LDLIBS)


### PR DESCRIPTION
A GNU Makefile has been provided for building this project.

This makes it easier to get it off the ground without having to discover what command line arguments need to be passed to the compiler.

Some notes:
- This uses the built-in rules for building a .cc to .o.
- A different 'llvm-config' to be provided to allow for building with LLVM installed to a different prefix (that is not on the path) or a different version.

As the project uses std::unique_ptr a C++11 compiler (or later) is required.
