### PR TITLE
Added support for LLVM 3.4, 3.5 and LLVM 5.0.

### DIFF
--- a/basiccompiler.cc
+++ b/basiccompiler.cc
@@ -3,7 +3,13 @@
 #include <llvm/IR/Module.h>
 #include <llvm/Support/raw_ostream.h>
 #include <llvm/Support/FileSystem.h>
+
+#if LLVM_VERSION_MAJOR >= 5
+#include <llvm/Bitcode/BitcodeWriter.h>
+#else
 #include <llvm/Bitcode/ReaderWriter.h>
+#endif
+
 #include "lexer.h"
 #include "parser.h"
 
@@ -22,7 +28,11 @@ int main(int argc, char **argv) {
     llvm::Module *mod = parser.generateModule();
     if (mod == nullptr) return 1;
 
+#if LLVM_VERSION_MAJOR > 3 || (LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR >= 6)
     std::error_code e;
+#else
+    std::string e;
+#endif
     llvm::raw_fd_ostream output_file(argv[2], e, llvm::sys::fs::OpenFlags::F_None);
     llvm::WriteBitcodeToFile(mod, output_file);
 

--- a/basiccompiler.cc
+++ b/basiccompiler.cc
@@ -4,7 +4,7 @@
 #include <llvm/Support/raw_ostream.h>
 #include <llvm/Support/FileSystem.h>
 
-#if LLVM_VERSION_MAJOR >= 5
+#if LLVM_VERSION_MAJOR >= 4
 #include <llvm/Bitcode/BitcodeWriter.h>
 #else
 #include <llvm/Bitcode/ReaderWriter.h>


### PR DESCRIPTION
- llvm::raw_fd_ostream started taking a std::error_code in LLVM 3.6.
  Prior to that it took a string (at least in 3.4 and 3.5). This based on building with various versions.
- <llvm/Bitcode/ReaderWriter.h> was split into seperate files for
  the reader and the writer in LLVM 5 (or possibly 4, I am unsure).

I have tested building with:
- 3.4
- 3.5
- 3.6
- 3.8
- 3.9
- 5.0

I haven't tested 3.7 but given the change for `std::error_code` occurred between 3.5 and 3.6 so I am confident these changes will work fine for 3.7.
