### PR TITLE
Fix printing a multi-digit. Previously it would only read the first digit

### DIFF
--- a/lexer.cc
+++ b/lexer.cc
@@ -128,14 +128,19 @@ bool BASICLexer::_push_cmp(std::stringstream &ss) {
 }
 
 bool BASICLexer::_push_const_str(std::stringstream &ss) {
-    std::string temp;
-    ss >> temp;
-    if (temp[0] != '"') {
+    while (std::isspace(ss.peek())) ss.ignore();
+    if (std::isdigit(ss.peek())) {
+        int value;
+        ss >> value;
+        _token_list.push_back(new ConstIntValueToken(value));
+    }
+    else if (ss.peek() != '"') {
+        std::string temp;
+        ss >> temp;
         _token_list.push_back(new VarIntValueToken(temp[0]));
     } else {
         std::string const_str;
         std::getline(ss, const_str);
-        const_str = temp + const_str;
         _token_list.push_back(
             new StringValueToken(const_str.substr(1, const_str.length() - 2)));
     }

--- a/parser.h
+++ b/parser.h
@@ -58,10 +58,12 @@ class PRINTInstruction : public Instruction {
   public:
     PRINTInstruction(int label, StringValueToken *str);
     PRINTInstruction(int label, VarIntValueToken *var);
+    PRINTInstruction(int label, ConstIntValueToken *var);
     virtual bool addToBuilder(llvm::IRBuilder<> *builder, llvm::Module *mod) override;
   private:
     StringValueToken *_str = nullptr;
     VarIntValueToken *_var = nullptr;
+    ConstIntValueToken *_number = nullptr;
 };
 class PRINTLNInstruction : public Instruction {
   public:


### PR DESCRIPTION
The print statement now supports reading a integer constant.

This means the following will output 42.
  10 PRINT 42

Previously, it was producing a segmentation fault and if that wasn't an issue it would have only saw the number 4. It was ignoring the 2.

Further work is required to handle expressions that can be addressed in a future pull request.

This fixes issue #5 